### PR TITLE
feat: switch all voice_active_crawler examples to Piper TTS by default

### DIFF
--- a/examples/16_tts.py
+++ b/examples/16_tts.py
@@ -1,14 +1,28 @@
 #!/usr/bin/env python3
 from robot_hat.tts import Piper, Espeak
 
-# Text-to-Speech demo using robot_hat TTS module
-# Press Ctrl+C to exit
+# ── Text-to-Speech demo for PiCrawler ───────────────────────────────────
+# Press Ctrl+C to exit.
+# The TTS engines available in robot_hat.tts / picrawler.tts are:
+#
+#   Piper      — local neural TTS, offline, fast (best quality)
+#   EdgeTTS    — free cloud TTS, 100+ voices, no API key
+#   Espeak     — compact offline TTS, robotic, fastest
+#   Pico2Wave  — compact offline TTS
+#
+# Just instantiate and call tts.say(text).
+#   from robot_hat.tts import Piper
+#   tts = Piper(model="en_US-ryan-low")        # English
+#   tts = Piper(model="zh_CN-huayan-x_low")    # Chinese
+#   from robot_hat.tts import EdgeTTS
+#   tts = EdgeTTS(voice="en-US-AriaNeural")
+#   from robot_hat.tts import Espeak, Pico2Wave
+#   tts = Espeak()
+#   tts = Pico2Wave()
 
-# Set USE_PIPER=True for high-quality neural TTS (Piper), False for Espeak
-USE_PIPER = True
-
-# Piper model: "en_US-ryan-low" (English), "zh_CN-huayan-x_low" (Chinese)
-TTS_MODEL = "en_US-ryan-low"
+# Choose TTS engine
+USE_PIPER = True          # True=Piper, False=Espeak
+TTS_MODEL = "en_US-ryan-low"   # Piper model (English); use "zh_CN-huayan-x_low" for Chinese
 
 def main():
     print("=== PiCrawler Text-to-Speech Demo ===")

--- a/examples/18_voice_active_crawler_gpt.py
+++ b/examples/18_voice_active_crawler_gpt.py
@@ -3,6 +3,25 @@ from secret import OPENAI_API_KEY as API_KEY
 
 from voice_active_crawler import VoiceActiveCrawler
 
+# ── TTS engines ──────────────────────────────────────────────────────────
+# Pick one. The VoiceAssistant accepts any TTS instance via the `tts=` parameter.
+
+# Default: Piper — local neural TTS, offline, fast
+from picrawler.tts import Piper
+tts = Piper(model="en_US-ryan-low")
+
+# EdgeTTS — free cloud TTS, 100+ voices, no API key
+# from picrawler.tts import EdgeTTS
+# tts = EdgeTTS(voice="en-US-AriaNeural")
+
+# Espeak — compact offline TTS, robotic, fastest
+# from picrawler.tts import Espeak
+# tts = Espeak()
+
+# Pico2Wave — compact offline TTS
+# from picrawler.tts import Pico2Wave
+# tts = Pico2Wave()
+
 llm = LLM(
     api_key=API_KEY,
     model="gpt-4o-mini",
@@ -15,7 +34,6 @@ NAME = "Buddy"
 WITH_IMAGE = True
 
 # Set models and languages
-TTS_MODEL = "en_US-ryan-low"
 STT_LANGUAGE = "en-us"
 
 # Enable keyboard input
@@ -67,7 +85,7 @@ vad = VoiceActiveCrawler(
     name=NAME,
     with_image=WITH_IMAGE,
     stt_language=STT_LANGUAGE,
-    tts_model=TTS_MODEL,
+    tts=tts,
     keyboard_enable=KEYBOARD_ENABLE,
     wake_enable=WAKE_ENABLE,
     wake_word=WAKE_WORD,

--- a/examples/19_voice_active_crawler_doubao.py
+++ b/examples/19_voice_active_crawler_doubao.py
@@ -3,6 +3,25 @@ from secret import DOUBAO_API_KEY as API_KEY
 
 from voice_active_crawler import VoiceActiveCrawler
 
+# ── TTS engines ──────────────────────────────────────────────────────────
+# Pick one. The VoiceAssistant accepts any TTS instance via the `tts=` parameter.
+
+# Default: Piper — local neural TTS, offline, fast
+from picrawler.tts import Piper
+tts = Piper(model="zh_CN-huayan-x_low")
+
+# EdgeTTS — free cloud TTS, 100+ voices, no API key
+# from picrawler.tts import EdgeTTS
+# tts = EdgeTTS(voice="zh-CN-XiaoxiaoNeural")
+
+# Espeak — compact offline TTS, robotic, fastest
+# from picrawler.tts import Espeak
+# tts = Espeak()
+
+# Pico2Wave — compact offline TTS
+# from picrawler.tts import Pico2Wave
+# tts = Pico2Wave()
+
 llm = LLM(
     api_key=API_KEY,
     model="doubao-seed-1-6-250615",
@@ -15,7 +34,6 @@ NAME = "旺财"
 WITH_IMAGE = True
 
 # 设置模型和语言
-TTS_MODEL = "zh_CN-huayan-x_low"
 STT_LANGUAGE = "cn"
 
 # 是否开启键盘输入
@@ -69,7 +87,7 @@ vad = VoiceActiveCrawler(
     name=NAME,
     with_image=WITH_IMAGE,
     stt_language=STT_LANGUAGE,
-    tts_model=TTS_MODEL,
+    tts=tts,
     keyboard_enable=KEYBOARD_ENABLE,
     wake_enable=WAKE_ENABLE,
     wake_word=WAKE_WORD,

--- a/examples/20_voice_active_crawler_ollama.py
+++ b/examples/20_voice_active_crawler_ollama.py
@@ -2,6 +2,25 @@ from picrawler.llm import Ollama as LLM
 
 from voice_active_crawler import VoiceActiveCrawler
 
+# ── TTS engines ──────────────────────────────────────────────────────────
+# Pick one. The VoiceAssistant accepts any TTS instance via the `tts=` parameter.
+
+# Default: Piper — local neural TTS, offline, fast
+from picrawler.tts import Piper
+tts = Piper(model="en_US-ryan-low")
+
+# EdgeTTS — free cloud TTS, 100+ voices, no API key
+# from picrawler.tts import EdgeTTS
+# tts = EdgeTTS(voice="en-US-AriaNeural")
+
+# Espeak — compact offline TTS, robotic, fastest
+# from picrawler.tts import Espeak
+# tts = Espeak()
+
+# Pico2Wave — compact offline TTS
+# from picrawler.tts import Pico2Wave
+# tts = Pico2Wave()
+
 # If Ollama runs on the same Raspberry Pi, use "localhost".
 # If it runs on another computer in your LAN, replace with that computer's IP address.
 llm = LLM(
@@ -16,7 +35,6 @@ NAME = "Buddy"
 WITH_IMAGE = False
 
 # Set models and languages
-TTS_MODEL = "en_US-ryan-low"
 STT_LANGUAGE = "en-us"
 
 # Enable keyboard input
@@ -68,7 +86,7 @@ vad = VoiceActiveCrawler(
     name=NAME,
     with_image=WITH_IMAGE,
     stt_language=STT_LANGUAGE,
-    tts_model=TTS_MODEL,
+    tts=tts,
     keyboard_enable=KEYBOARD_ENABLE,
     wake_enable=WAKE_ENABLE,
     wake_word=WAKE_WORD,


### PR DESCRIPTION
Apply the same TTS injection pattern from pidog PR #16 to picrawler voice_active_crawler examples.

## What changed

In each voice_active_crawler example:
- **Added a TTS engines block** before the LLM setup, with Piper as default and EdgeTTS/Espeak/Pico2Wave as commented alternatives
- **Removed the old** `TTS_MODEL = "..."` variable
- **Changed** `tts_model=TTS_MODEL` → `tts=tts` (the VoiceAssistant already supports the `tts=` parameter)

### Files modified

| File | Default TTS |
|------|-------------|
| **18_voice_active_crawler_gpt.py** | Piper `en_US-ryan-low` |
| **19_voice_active_crawler_doubao.py** | Piper `zh_CN-huayan-x_low` (Chinese) |
| **20_voice_active_crawler_ollama.py** | Piper `en_US-ryan-low` |
| **16_tts.py** | Added documentation for all 4 TTS engines |

### Why

This matches the pattern established in sunfounder/pidog#16. Users can easily switch TTS engines by uncommenting lines instead of modifying variables. The `tts=` injection approach also supports passing custom TTS instances.